### PR TITLE
Add Sercom0 support + example for Arduino MKR ZERO

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # SercomSPISlave
 
 ## Introduction
-This is a Sercom SPI library used for ATSAMD21 boards, such as the Arduino Zero and Adafruit Feather M0. It provides functions to setup SPI Slaves using Sercom1 and Sercom4.
+This is a Sercom SPI library used for ATSAMD21 boards, such as the Arduino Zero, Arduino MKR ZERO and Adafruit Feather M0. It provides functions to setup SPI Slaves using Sercom0, Sercom1 and Sercom4.
 
 To use it with the Arduino IDE, simply copy the the folder into the Arduino library folder.
 
-Two examples are provided to set up a:
+Examples are provided to set up a:
+- Sercom0 SPI Slave
 - Sercom1 SPI Slave
 - Sercom4 SPI Slave
 
@@ -13,7 +14,16 @@ Two examples are provided to set up a:
 Setting up a board as a SPI slave can be used to for instance communicate over SPI between a Raspberry Pi (SPI master) and an ATSAMD21 based board (SPI slave).
 
 ## Hardware implementation
-The pins used when the board is set up as an SPI Slave using Sercom1 are:
+The pins used when the board is set up as an SPI Slave using the different Sercom are:
+### Sercom0
+| SPI pin | description         | ATSAMD21 pin |
+|---------|---------------------|--------------|
+| MOSI    | Master Out Slave In | PA08         |
+| SCK     | Serial Clock        | PA09         |
+| SS      | Slave Select        | PA10         |
+| MISO    | Master In Slave Out | PA11         |
+
+### Sercom1
 | SPI pin | description         | ATSAMD21 pin |
 |---------|---------------------|--------------|
 | MOSI    | Master Out Slave In | PA16         |
@@ -21,7 +31,7 @@ The pins used when the board is set up as an SPI Slave using Sercom1 are:
 | SS      | Slave Select        | PA18         |
 | MISO    | Master In Slave Out | PA19         |
 
-The pins used when the board is set up as an SPI Slave using Sercom4 are:
+### Sercom4
 | SPI pin | description         | ATSAMD21 pin |
 |---------|---------------------|--------------|
 | MOSI    | Master Out Slave In | PA12         |

--- a/SercomSPISlave.h
+++ b/SercomSPISlave.h
@@ -9,6 +9,7 @@ class SercomSPISlave
     // Constructors //
     SercomSPISlave();
     // Public Methods //
+    void Sercom0init();
     void Sercom1init();
     void Sercom4init();
 };

--- a/examples/Sercom0SPISlave/Sercom0SPISlave.ino
+++ b/examples/Sercom0SPISlave/Sercom0SPISlave.ino
@@ -1,0 +1,72 @@
+
+/*
+  Example code for the SercomSPISlave library
+  This code initializes a SERCOM0 SPI Slave and prints the data received.
+
+  Example written by stubb
+  2020
+*/
+
+#include <SercomSPISlave.h>
+SercomSPISlave SPISlave;
+
+#define DEBUG // comment this line out to not print debug data on the serial bus
+
+void setup()
+{  
+  Serial.begin(115200);
+  Serial.println("Serial started");
+  SPISlave.Sercom0init();
+  Serial.println("SERCOM0 SPI slave initialized");
+}
+
+void loop()
+{
+  Serial.println("nodata");
+  delay(1000);
+}
+
+void SERCOM0_Handler() // 25.7 Register Summary, page 454 atmel 42181, samd21
+{ 
+  #ifdef DEBUG
+    Serial.println("In SPI Interrupt");
+  #endif
+  uint8_t data = 0;
+  data = (uint8_t)SERCOM0->SPI.DATA.reg;
+  uint8_t interrupts = SERCOM0->SPI.INTFLAG.reg; //Read SPI interrupt register
+  #ifdef DEBUG
+    Serial.print("Interrupt: "); Serial.println(interrupts);
+  #endif
+  if (interrupts & (1 << 3)) // 8 = 1000 = SSL
+  {
+    #ifdef DEBUG
+      Serial.println("SPI SSL Interupt");
+    #endif
+    SERCOM0->SPI.INTFLAG.bit.SSL = 1; //clear slave select interrupt
+  }
+  if (interrupts & (1 << 2)) // 4 = 0100 = RXC
+  {
+    #ifdef DEBUG
+      Serial.println("SPI Data Received Complete Interrupt");
+    #endif
+    data = SERCOM0->SPI.DATA.reg; //Read data register
+    SERCOM0->SPI.INTFLAG.bit.RXC = 1; //clear receive complete interrupt
+  }
+  if (interrupts & (1 << 1)) // 2 = 0010 = TXC
+  {
+    #ifdef DEBUG
+      Serial.println("SPI Data Transmit Complete Interrupt");
+    #endif
+    SERCOM0->SPI.INTFLAG.bit.TXC = 1; //clear receive complete interrupt
+  }
+
+  if (interrupts & (1 << 0)) // 1 = 0001 = DRE
+  {
+    #ifdef DEBUG
+      Serial.println("SPI Data Register Empty Interrupt");
+    #endif
+    SERCOM0->SPI.DATA.reg = 0xAA;
+  }
+  char _data = data;
+  Serial.println(_data); // print received data
+}


### PR DESCRIPTION
Adds support for using the Sercom0 pins. Provides an example and updates the readme file.
Testet both with an Arduino MKR ZERO board as SPI Slave device.